### PR TITLE
Cannot import ZopeTransactionExtension

### DIFF
--- a/puzzlesweb/model/__init__.py
+++ b/puzzlesweb/model/__init__.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 """The application's model objects"""
 
-from zope.sqlalchemy import ZopeTransactionExtension
+from zope.sqlalchemy import register
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 
 # Global session manager: DBSession() returns the Thread-local
 # session object appropriate for the current web request.
-maker = sessionmaker(autoflush=True, autocommit=False,
-                     extension=ZopeTransactionExtension())
+maker = sessionmaker(autoflush=True, autocommit=False)
+register(maker)
 DBSession = scoped_session(maker)
 
 # Base class for all of our model classes: By default, the data model is

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ install_requires = [
     "Babel",
     "filedepot",
     "markdown",
+    "requests",
 ]
 
 setup(


### PR DESCRIPTION
The follow error occurs when trying to `gearbox setup-app`.
```
21:11:50,617 ERROR [gearbox] cannot import name 'ZopeTransactionExtension' from 'zope.sqlalchemy' (/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/zope/sqlalchemy/__init__.py)
Traceback (most recent call last):
  File "/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/gearbox/main.py", line 172, in _run_subcommand
    return cmd.run(parsed_args)
  File "/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/gearbox/command.py", line 31, in run
    self.take_action(parsed_args)
  File "/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/gearbox/commands/setup_app.py", line 46, in take_action
    conf = appconfig(config_spec, relative_to=os.getcwd())
  File "/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/paste/deploy/loadwsgi.py", line 265, in appconfig
    context = loadcontext(APP, uri, name=name,
  File "/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/paste/deploy/loadwsgi.py", line 299, in loadcontext
    return _loaders[scheme](
  File "/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/paste/deploy/loadwsgi.py", line 326, in _loadconfig
    return loader.get_context(object_type, name, global_conf)
  File "/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/paste/deploy/loadwsgi.py", line 457, in get_context
    context = self._context_from_use(
  File "/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/paste/deploy/loadwsgi.py", line 480, in _context_from_use
    context = self.get_context(
  File "/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/paste/deploy/loadwsgi.py", line 410, in get_context
    return loadcontext(object_type, name,
  File "/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/paste/deploy/loadwsgi.py", line 299, in loadcontext
    return _loaders[scheme](
  File "/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/paste/deploy/loadwsgi.py", line 334, in _loadegg
    return loader.get_context(object_type, name, global_conf)
  File "/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/paste/deploy/loadwsgi.py", line 624, in get_context
    entry_point, protocol, ep_name = self.find_egg_entry_point(
  File "/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/paste/deploy/loadwsgi.py", line 651, in find_egg_entry_point
    possible.append((entry.load(), protocol, entry.name))
  File "/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2443, in load
    return self.resolve()
  File "/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/edwargix/git/puzzle-challenge-website/puzzlesweb/config/middleware.py", line 4, in <module>
    from puzzlesweb.config.app_cfg import base_config
  File "/home/edwargix/git/puzzle-challenge-website/puzzlesweb/config/app_cfg.py", line 14, in <module>
    import puzzlesweb.model as model
  File "/home/edwargix/git/puzzle-challenge-website/puzzlesweb/model/__init__.py", line 4, in <module>
    from zope.sqlalchemy import ZopeTransactionExtension
ImportError: cannot import name 'ZopeTransactionExtension' from 'zope.sqlalchemy' (/home/edwargix/git/puzzle-challenge-website/.venv/lib/python3.8/site-packages/zope/sqlalchemy/__init__.py)
```

It's because of [this](https://pypi.org/project/zope.sqlalchemy/#id3) change to zope.sqlalchemy.  This pull request makes the necessary changes.